### PR TITLE
Adds a couple of dependencies for initial migration

### DIFF
--- a/varify/assessments/migrations/0001_initial.py
+++ b/varify/assessments/migrations/0001_initial.py
@@ -7,6 +7,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ("samples", "0001_initial"),
+    )
+
     def forwards(self, orm):
         # Adding model 'Pathogenicity'
         db.create_table('pathogenicity', (

--- a/varify/migrations/0006_avocado_metadata_migration.py
+++ b/varify/migrations/0006_avocado_metadata_migration.py
@@ -3,6 +3,10 @@ from south.v2 import DataMigration
 
 class Migration(DataMigration):
 
+    depends_on = (
+        ('samples', '0001_initial'),
+    )
+
     def forwards(self, orm):
         "Perform a 'safe' load using Avocado's backup utilities."
         from avocado.core import backup


### PR DESCRIPTION
While setting up Varify, I noticed that there were a couple of unmet dependencies for the initial migrations to cleanly take place. eed5bb7414cde802963df0fa5145d450b6068491 fixes the assessment migration that actually throws an exception. While, e19addc209e3112c52ae061a3afa3fb3e7745f79, allows the last fixture to be loaded. 

:thumbsup: Thanks for building this--it looks awesome!
