### PR TITLE
Use 'name' as the label field for GeneSet model

### DIFF
--- a/varify/genes/models.py
+++ b/varify/genes/models.py
@@ -127,6 +127,7 @@ class GeneSet(ObjectSet):
     published = models.BooleanField(default=True)
 
     set_object_rel = 'genes'
+    label_field = 'name'
 
     def __unicode__(self):
         return unicode(self.name)


### PR DESCRIPTION
Fix #115.

This fixes issues in the display where the PK was being used as the
label field which is not nearly as informative or clear as using the
name field.
