### PR TITLE
Fix case where polyphen2 never rendered when SIFT present

### DIFF
--- a/varify/static/scripts/coffeescript/ui/modals/result.coffee
+++ b/varify/static/scripts/coffeescript/ui/modals/result.coffee
@@ -65,25 +65,25 @@ define [
             content.push '<h4>Prediction Scores</h4>'
             content.push '<ul class=unstyled>'
 
-            if (sift = attrs.sift[0]) or (pp2 = attrs.polyphen2[0])
-                # SIFT
-                if sift
-                    labelClass = ''
-                    switch sift.prediction
-                        when 'Damaging' then labelClass = 'text-error'
-                        else labelClass = 'muted'
-                    content.push "<li><small>SIFT</small> <span class=#{ labelClass }>#{ sift.prediction }</span></li>"
+            # SIFT
+            if (sift = attrs.sift[0])
+                labelClass = ''
+                switch sift.prediction
+                    when 'Damaging' then labelClass = 'text-error'
+                    else labelClass = 'muted'
+                content.push "<li><small>SIFT</small> <span class=#{ labelClass }>#{ sift.prediction }</span></li>"
 
-                # PolyPhen2
-                if pp2
-                    labelClass = ''
-                    switch pp2.prediction
-                        when 'Probably Damaging' then labelClass = 'text-error'
-                        when 'Possibly Damaging' then labelClass = 'text-warning'
-                        else labelClass = 'muted'
-                    content.push "<li><small>PolyPhen2</small> <span class=#{ labelClass }>#{ pp2.prediction }</span></li>"
-                content.push '</ul>'
-            else
+            # PolyPhen2
+            if (pp2 = attrs.polyphen2[0])
+                labelClass = ''
+                switch pp2.prediction
+                    when 'Probably Damaging' then labelClass = 'text-error'
+                    when 'Possibly Damaging' then labelClass = 'text-warning'
+                    else labelClass = 'muted'
+                content.push "<li><small>PolyPhen2</small> <span class=#{ labelClass }>#{ pp2.prediction }</span></li>"
+
+            content.push '</ul>'
+            if not (sift or pp2)
                 content.push '<p class=muted>No predictions scores</p>'
 
             return content.join ''

--- a/varify/static/scripts/javascript/src/ui/modals/result.js
+++ b/varify/static/scripts/javascript/src/ui/modals/result.js
@@ -69,34 +69,33 @@ define(['underscore', 'marionette', '../../models', '../../utils', '../../templa
       content = [];
       content.push('<h4>Prediction Scores</h4>');
       content.push('<ul class=unstyled>');
-      if ((sift = attrs.sift[0]) || (pp2 = attrs.polyphen2[0])) {
-        if (sift) {
-          labelClass = '';
-          switch (sift.prediction) {
-            case 'Damaging':
-              labelClass = 'text-error';
-              break;
-            default:
-              labelClass = 'muted';
-          }
-          content.push("<li><small>SIFT</small> <span class=" + labelClass + ">" + sift.prediction + "</span></li>");
+      if ((sift = attrs.sift[0])) {
+        labelClass = '';
+        switch (sift.prediction) {
+          case 'Damaging':
+            labelClass = 'text-error';
+            break;
+          default:
+            labelClass = 'muted';
         }
-        if (pp2) {
-          labelClass = '';
-          switch (pp2.prediction) {
-            case 'Probably Damaging':
-              labelClass = 'text-error';
-              break;
-            case 'Possibly Damaging':
-              labelClass = 'text-warning';
-              break;
-            default:
-              labelClass = 'muted';
-          }
-          content.push("<li><small>PolyPhen2</small> <span class=" + labelClass + ">" + pp2.prediction + "</span></li>");
+        content.push("<li><small>SIFT</small> <span class=" + labelClass + ">" + sift.prediction + "</span></li>");
+      }
+      if ((pp2 = attrs.polyphen2[0])) {
+        labelClass = '';
+        switch (pp2.prediction) {
+          case 'Probably Damaging':
+            labelClass = 'text-error';
+            break;
+          case 'Possibly Damaging':
+            labelClass = 'text-warning';
+            break;
+          default:
+            labelClass = 'muted';
         }
-        content.push('</ul>');
-      } else {
+        content.push("<li><small>PolyPhen2</small> <span class=" + labelClass + ">" + pp2.prediction + "</span></li>");
+      }
+      content.push('</ul>');
+      if (!(sift || pp2)) {
         content.push('<p class=muted>No predictions scores</p>');
       }
       return content.join('');


### PR DESCRIPTION
Fix #110.

This was caused due to the lazy evaluation logic. Basically, if SIFT was present, then the sift variable was define and evaluated to true. As a result, the lazy or evaluation stopped there an never considered the second statement which assigned the polyphen portion.
