### PR TITLE
Fix problems reading data from PyVCF call objects

### DIFF
--- a/varify/genome/fixtures/initial_data.json
+++ b/varify/genome/fixtures/initial_data.json
@@ -309,5 +309,45 @@
             "order": 4,
             "code": 4
         }
+    },
+    {
+        "model": "genome.genotype",
+        "pk": 5,
+        "fields": {
+            "label": "Het Ref",
+            "value": "0/2",
+            "order": 5,
+            "code": 5
+        }
+    },
+    {
+        "model": "genome.genotype",
+        "pk": 6,
+        "fields": {
+            "label": "Hom Alt",
+            "value": "2/2",
+            "order": 6,
+            "code": 6
+        }
+    },
+    {
+        "model": "genome.genotype",
+        "pk": 7,
+        "fields": {
+            "label": "Het Mult Ref",
+            "value": "0/#",
+            "order": 7,
+            "code": 7
+        }
+    },
+    {
+        "model": "genome.genotype",
+        "pk": 8,
+        "fields": {
+            "label": "Hom Mult Alle",
+            "value": "#/#",
+            "order": 8,
+            "code": 8
+        }
     }
 ]

--- a/varify/samples/management/subcommands/load.py
+++ b/varify/samples/management/subcommands/load.py
@@ -183,22 +183,24 @@ class Command(BaseCommand):
         variant = self.get_variant(record)
         info = record.INFO
 
-        genotype = self.get_genotype(call['GT'])
+        genotype = self.get_genotype(getattr(call.data, 'GT', None))
+
+        ad = getattr(call.data, 'AD', None)
 
         # Create result
         result = Result(
             quality=record.QUAL,
 
-            read_depth=getattr(call, 'DP', None),
+            read_depth=getattr(call.data, 'DP', None),
 
             genotype=genotype,
-            genotype_quality=getattr(call, 'GQ', None),
+            genotype_quality=getattr(call.data, 'GQ', None),
 
-            coverage_ref=call['AD'][0] if getattr(call, 'AD') else None,
-            coverage_alt=call['AD'][1] if getattr(call, 'AD') else None,
+            coverage_ref=ad[0] if ad and len(ad) > 0 else None,
+            coverage_alt=ad[1] if ad and len(ad) > 1 else None,
 
             phred_scaled_likelihood=','.join(
-                [str(x) for x in getattr(call, 'PL', [])]),
+                [str(x) for x in getattr(call.data, 'PL', [])]),
 
             in_dbsnp=bool(self.clean_value(info, 'DB')),
 

--- a/varify/samples/pipeline/handlers.py
+++ b/varify/samples/pipeline/handlers.py
@@ -203,7 +203,7 @@ def load_results(manifest_path, database, **kwargs):
                         sample.save()
                         successful = True
                 except:
-                    log.error('STS errors')
+                    log.exception('STS errors')
                     time.sleep(10)
 
     vcf_info = manifest.section('vcf')

--- a/varify/samples/pipeline/utils.py
+++ b/varify/samples/pipeline/utils.py
@@ -65,7 +65,7 @@ class ResultStream(VCFPGCopyEditor):
         # The possibility for multiple alleles in these wide vcfs is almost
         # infinite so we need to triage the really weird ones into having a
         # reference allele "0/#" or being off the map entirely "#/#"".
-        gt = getattr(call, 'GT', None)
+        gt = getattr(call.data, 'GT', None)
         if gt:
             try:
                 keyed_geno = self.genotypes[gt]
@@ -77,16 +77,16 @@ class ResultStream(VCFPGCopyEditor):
         else:
             keyed_geno = None
 
-        dp = getattr(call, 'DP', None)
-        gq = getattr(call, 'GQ', None)
-        ad = getattr(call, 'AD', None)
+        dp = getattr(call.data, 'DP', None)
+        gq = getattr(call.data, 'GQ', None)
+        ad = getattr(call.data, 'AD', None)
         if ad and len(ad) > 1:
             ad0 = ad[0]
             ad1 = ad[1]
         else:
             ad0 = None
             ad1 = None
-        pl = getattr(call, 'PL', None)
+        pl = getattr(call.data, 'PL', None)
         if pl:
             pl = ','.join([str(x) for x in pl])
 


### PR DESCRIPTION
Fix #132.

This was originally caused by my changes to the internal copy of Varify that removed explicit indexing like `call['GT']` in favor of(what I thought to be) safer retrieval. The problem was, PyVCF was overriding the `__getitem__` method so while I thought the actual data was on the `call` object, it was really on the `data` property of the `call` object. Since PyVCF, always assuming the key is valid when using indexing, we don't want to use that again since we don't want to wrap all our indexes in try/except blocks for `AttributeError`s. Instead, we use a safe version of `getattr()` on the `call.data` object itself where we specify the default value. [PyVCF does not do this](https://github.com/cbmi/PyVCF/blob/master/vcf/model.py#L90-L92) in `__getitem__` so any invalid attributes trigger an `AttributeError` and can cause loader problems.
