### PR TITLE
Add command and script for updating gene rankings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
     - pip install -r requirements.txt
     - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors cython && pip install --use-mirrors pysam argparse counter ordereddict importlib; fi"
     - pip install flake8
+    - pip install httpretty
 services:
     - memcached
     - redis-server

--- a/recalculate_gene_ranks.py
+++ b/recalculate_gene_ranks.py
@@ -1,0 +1,33 @@
+import django_rq
+import logging
+import os
+import time
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'varify.conf.settings')
+
+from django.core import management
+
+log = logging.getLogger(__name__)
+
+# We don't want this job to run forever so limit to this many attempts and
+# if the queue is still not empty just give up.
+MAX_ATTEMPTS = 100
+# Time in seconds between polling the queue for the current count
+POLL_DELAY = 300
+
+queue = django_rq.get_queue('default')
+
+attempts = 0
+
+while attempts < MAX_ATTEMPTS:
+    attempts += 1
+    if queue.is_empty:
+        management.call_command('samples', 'gene-ranks')
+        log.debug('gene ranks updated')
+        break
+    log.debug('queue not empty, waiting {0} seconds'.format(POLL_DELAY))
+    time.sleep(POLL_DELAY)
+else:
+    # Max attempts, log and exit
+    log.error('Maximum attempts ({0}) made when trying to update gene ranks.'
+              .format(MAX_ATTEMPTS))

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ kwargs = {
     'include_package_data': True,
     'install_requires': install_requires,
     'test_suite': 'test_suite',
+    'tests_require': ['httpretty'],
     'author': '',
     'author_email': '',
     'description': '',

--- a/tests/cases/commands/tests.py
+++ b/tests/cases/commands/tests.py
@@ -158,6 +158,11 @@ class GeneRanksTestCase(TestCase):
             re.compile("http://localhost/api/tests/phenotype/(.*)/"),
             body=self.mock_phenotype,
             content_type="application/json")
+        httpretty.register_uri(
+            httpretty.GET,
+            re.compile(
+                "http://localhost/api/tests/genotype_exception(.*)"),
+            body=self.mock_request_exception)
 
     def test_missing_settings(self):
         error_log_count = len(self.mock_handler.messages['error'])
@@ -240,6 +245,16 @@ class GeneRanksTestCase(TestCase):
             self.assertTrue(self.mock_handler.messages['warning'])
             self.assertTrue("because it has no HPO terms" in
                             self.mock_handler.messages['warning'][-1])
+
+        with self.settings(PHENOTYPE_ENDPOINT=
+                           'http://localhost/api/tests/phenotype/%s/',
+                           GENE_RANK_BASE_URL=
+                           'http://localhost/api/tests/genotype_exception'):
+            management.call_command('samples', 'gene-ranks', 'NA12878')
+
+            self.assertTrue(self.mock_handler.messages['error'])
+            self.assertTrue('Error retrieving gene rankings' in
+                            self.mock_handler.messages['error'][-1])
 
         # We still shouldn't have any ResultScores as we've been nothing but a
         # failure to this point.

--- a/tests/cases/commands/tests.py
+++ b/tests/cases/commands/tests.py
@@ -20,6 +20,7 @@ TESTS_DIR = os.path.join(os.path.dirname(__file__), '../..')
 SAMPLE_DIRS = [os.path.join(TESTS_DIR, 'samples', 'batch1')]
 
 
+@override_settings(VARIFY_AUTO_CREATE_COHORT=False)
 class GeneRanksTestCase(TestCase):
     fixtures = ['test_data.json']
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,19 @@
+import logging
+
+
+class MockHandler(logging.Handler):
+    def __init__(self, *args, **kwargs):
+        self.reset()
+        logging.Handler.__init__(self, *args, **kwargs)
+
+    def emit(self, record):
+        self.messages[record.levelname.lower()].append(record.getMessage())
+
+    def reset(self):
+        self.messages = {
+            'debug': [],
+            'info': [],
+            'warning': [],
+            'error': [],
+            'critical': [],
+        }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -8,6 +8,7 @@ DATABASES = {
 }
 
 INSTALLED_APPS = (
+    'tests',
     'tests.cases.south_tests',
     'tests.cases.geneset_form',
     'tests.cases.sample_load_process',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -108,12 +108,12 @@ LOGGING = {
     'loggers': {
         'varify': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': 'INFO',
             'propagate': True,
         },
         'tests': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': 'INFO',
             'propagate': True,
         },
         'rq.worker': {

--- a/varify/samples/management/commands/samples.py
+++ b/varify/samples/management/commands/samples.py
@@ -6,6 +6,7 @@ class Command(Subcommander):
 
     subcommands = {
         'allele-freqs': 'allele_freqs',
+        'gene-ranks': 'gene_ranks',
         'queue': 'queue',
         'delete-sample': 'delete_sample',
         'delete-project': 'delete_project',

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -222,6 +222,7 @@ class Command(BaseCommand):
                         log.exception("Error saving gene ranks and scores for "
                                       "sample '{0}'".format(sample.label))
                         transaction.rollback()
+                        continue
 
                     transaction.commit()
 

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -1,0 +1,213 @@
+import json
+import logging
+import requests
+from datetime import datetime
+from django.conf import settings
+from optparse import make_option
+from django.db import transaction, DEFAULT_DB_ALIAS
+from django.core.management.base import BaseCommand
+from requests.exceptions import SSLError, ConnectionError, RequestException
+from varify.samples.models import Sample
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
+        make_option('--database', action='store', dest='database',
+                    default=DEFAULT_DB_ALIAS,
+                    help='Specifies the target database to load results.'),
+        make_option('--force', action='store_true', dest='force',
+                    default=False,
+                    help='Forces recomputation of all gene rankings')
+    )
+
+    def handle(self, **options):
+        if not settings.PHENOTYPE_ENDPOINT:
+            log.error('PHENOTYPE_ENDPOINT must be defined in settings for '
+                      'gene rankings to be updated.')
+            return
+
+        if not settings.GENE_RANK_BASE_URL:
+            log.error('GENE_RANK_BASE_URL must be defined in settings for '
+                      'gene rankings to be updated.')
+            return
+
+        if not settings.VARIFY_CERT or not settings.VARIFY_KEY:
+            log.error('VARIFY_CERT and VARIFY_KEY must be defined in settings '
+                      'for gene rankings to be updated.')
+            return
+
+        database = options.get('database')
+        force = options.get('force')
+
+        # Construct the cert from the setting to use in requests to the
+        # phenotype endpoint.
+        cert = (settings.VARIFY_CERT, settings.VARIFY_KEY)
+
+        # We ignore all the samples that aren't published. They aren't visible
+        # to the user so we don't bother updating related scores.
+        samples = Sample.objects.filter(published=True)
+
+        updated_samples = 0
+        total_samples = 0
+        for sample in samples:
+            total_samples += 1
+
+            # Construct the URL from the setting and the sample label. The
+            # sample label is used to retrieve the phenotype info on the remote
+            # endpoint.
+            url = settings.PHENOTYPE_ENDPOINT % sample.label
+
+            # Get the phenotype information for this sample. If the
+            # phenotype is unavailable then we can skip this sample.
+            try:
+                response = requests.get(url, cert=cert, verify=False)
+            except SSLError:
+                log.exception('Skipping sample "{0}". An SSLError occurred '
+                              'during phenotype retrieval request.'
+                              .format(sample.label))
+                continue
+            except ConnectionError:
+                log.exception('Skipping sample "{0}". A ConnectionError '
+                              'occurred during phenotype retrieval request.'
+                              .format(sample.label))
+                continue
+            except RequestException:
+                log.exception('Skipping sample "{0}". The sample has no '
+                              'phenotype data associated with it'
+                              .format(sample.label))
+                continue
+
+            try:
+                phenotype_data = json.loads(response.content)
+            except ValueError:
+                log.error("Could not parse response from {0}, skipping '{1}'."
+                          .format(url, sample.label))
+                continue
+
+            try:
+                phenotype_modified = datetime.strptime(
+                    phenotype_data['last_modified'], "%Y-%m-%dT%H:%M:%S.%f")
+            except ValueError:
+                phenotype_modified = datetime.min
+                log.warn("Could not parse 'last_modified' field on phenotype "
+                         "data. Using datetime.min so that only unranked "
+                         "samples will be ranked. If the 'force' flag was "
+                         "used then all samples will be updated despite this "
+                         "parsing failure.")
+
+            if (not force and sample.phenotype_modified and
+                    sample.phenotype_modified < phenotype_modified):
+                log.debug("Sample '{0}' is already up to date, skipping it."
+                          .format(sample.label))
+                continue
+
+            # Extract the HPO terms from the data returned from the phenotype
+            # endpoint. We need to modify the terms a bit because the phenotype
+            # endpoint has terms in the form 'HP_0011263' and the gene ranking
+            # enpoint expects them to be of the form 'HP:0011263'.
+            hpo_terms = []
+            for hpo_annotation in phenotype_data['hpoAnnotations']:
+                hpo_id = str(hpo_annotation.get('hpo_id', ''))
+
+                if hpo_id:
+                    hpo_terms.append(hpo_id.replace('_', ':'))
+
+            # If there are no HPO terms then there will be no rankings so skip
+            # this sample to avoid any more computations and requests.
+            if not hpo_terms:
+                log.warning('Skipping "{0}" because it has no HPO terms '
+                            'associated with it.'.format(sample.label))
+                continue
+
+            # Compute the unique gene list for the entire sample
+            genes = set(sample.results.values_list(
+                'variant__effects__transcript__gene__symbol', flat=True))
+
+            # Obviously, if there are no genes then the gene ranking endpoint
+            # will have nothing to do so we can safely skip this sample.
+            if not genes:
+                continue
+
+            # We need to convert the genes to strings because the ranking
+            # service is no prepared to handle the unicode format that the
+            # gene symbols are in when we retrieve them from the models.
+            gene_rank_url = "http://{0}?hpo={1}&genes={2}".format(
+                settings.GENE_RANK_BASE_URL, ",".join(hpo_terms),
+                ",".join([str(g) for g in genes]))
+
+            try:
+                gene_response = requests.get(gene_rank_url)
+            except Exception:
+                log.exception('Error retrieving gene rankings')
+                continue
+
+            gene_data = json.loads(gene_response.content)
+            ranked_genes = gene_data['ranked_genes']
+
+            # While all the results should have been updated at the
+            # same time, we cannot guarantee that so we check if each
+            # is stale or the force flag is on before updating the
+            # results gene rank.
+            updated_results = 0
+            total_results = 0
+            for result in sample.results.all():
+                total_results += 1
+
+                with transaction.commit_manually(database):
+                    try:
+                        # Get the gene for this result. Since a result can
+                        # have more than one gene associated with it, we
+                        # return the first gene symbol in the list. This is
+                        # the same one that will be shown in the collapsed
+                        # gene list on the variant row in the results table.
+                        gene = result.variant.effects.values_list(
+                            'transcript__gene__symbol', flat=True)[0]
+
+                        # If there is no gene on this result or the gene is
+                        # not found in the list of ranked genes then skip this
+                        # result.
+                        if not gene:
+                            log.debug("Result with id {0} has no gene, "
+                                      "skipping result.".format(result.id))
+                            transaction.rollback()
+                            continue
+
+                        # Get the first item in the ranked gene list with a
+                        # symbol matching the gene we looked up above for this
+                        # result.
+                        ranked_gene = next(
+                            (r for r in ranked_genes if
+                             r.get('symbol', '').lower() == gene.lower()),
+                            None)
+
+                        if not ranked_gene:
+                            log.debug("Could not find '{0}' in ranked gene "
+                                      "list, skipping result".format(gene))
+                            transaction.rollback()
+                            continue
+
+                        result.score.rank = ranked_gene.get('rank', None)
+                        result.score.score = ranked_gene.get('score', None)
+                        result.save()
+
+                        updated_results += 1
+
+                    except Exception:
+                        log.exception("Error saving gene ranks and scores for "
+                                      "sample '{0}'".format(sample.label))
+                        transaction.rollback()
+
+                    transaction.commit()
+
+            sample.phenotype_modified = datetime.now()
+            sample.save()
+
+            log.info("Updated {0} and skipped {1} results in sample '{2}'"
+                     .format(updated_results, total_results - updated_results,
+                             sample.label))
+            updated_samples += 1
+
+        log.info("Updated {0} and skipped {1} samples"
+                 .format(updated_samples, total_samples-updated_samples))

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -24,18 +24,18 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        if getattr(settings, 'PHENOTYPE_ENDPOINT', None):
+        if not getattr(settings, 'PHENOTYPE_ENDPOINT', None):
             log.error('PHENOTYPE_ENDPOINT must be defined in settings for '
                       'gene rankings to be updated.')
             return
 
-        if getattr(settings, 'GENE_RANK_BASE_URL', None):
+        if not getattr(settings, 'GENE_RANK_BASE_URL', None):
             log.error('GENE_RANK_BASE_URL must be defined in settings for '
                       'gene rankings to be updated.')
             return
 
-        if (getattr(settings, 'VARIFY_CERT', None) or not
-                getattr(settings, 'VARIFY_KEY', None)):
+        if (not getattr(settings, 'VARIFY_CERT', None) or
+                not getattr(settings, 'VARIFY_KEY', None)):
             log.error('VARIFY_CERT and VARIFY_KEY must be defined in settings '
                       'for gene rankings to be updated.')
             return
@@ -65,7 +65,7 @@ class Command(BaseCommand):
             # Construct the URL from the setting and the sample label. The
             # sample label is used to retrieve the phenotype info on the remote
             # endpoint.
-            url = settings.PHENOTYPE_ENDPOINT % sample.label
+            url = settings.PHENOTYPE_ENDPOINT.format(sample.label)
 
             # Get the phenotype information for this sample. If the
             # phenotype is unavailable then we can skip this sample.

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -111,7 +111,7 @@ class Command(BaseCommand):
                 continue
 
             if (not force and sample.phenotype_modified and
-                    sample.phenotype_modified < phenotype_modified):
+                    sample.phenotype_modified > phenotype_modified):
                 log.debug("Sample '{0}' is already up to date, skipping it."
                           .format(sample.label))
                 continue

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -165,10 +165,6 @@ class Command(BaseCommand):
             gene_data = json.loads(gene_response.content)
             ranked_genes = gene_data['ranked_genes']
 
-            # While all the results should have been updated at the
-            # same time, we cannot guarantee that so we check if each
-            # is stale or the force flag is on before updating the
-            # results gene rank.
             updated_results = 0
             total_results = 0
             for result in sample.results.all():

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -107,7 +107,7 @@ class Command(BaseCommand):
 
             # If the parsed response doesn't contain any HPO terms then we can
             # skip this sample since we cannot rank genes without HPO terms.
-            if not phenotype_data.get('hpoAnnotations', []):
+            if not phenotype_data.get('hpoAnnotations'):
                 log.error("Response from phenotype missing HPO Annotations, "
                           "skipping '{0}'.".format(sample.label))
                 continue
@@ -125,7 +125,7 @@ class Command(BaseCommand):
             hpo_terms = []
             for hpo_annotation in phenotype_data['hpoAnnotations']:
                 try:
-                    hpo_id = str(hpo_annotation.get('hpo_id', ''))
+                    hpo_id = str(hpo_annotation.get('hpo_id'))
                 except AttributeError:
                     continue
 
@@ -196,7 +196,7 @@ class Command(BaseCommand):
                         # result.
                         ranked_gene = next(
                             (r for r in ranked_genes if
-                             r.get('symbol', '').lower() == gene.lower()),
+                             r.get('symbol').lower() == gene.lower()),
                             None)
 
                         if not ranked_gene:
@@ -207,13 +207,13 @@ class Command(BaseCommand):
 
                         try:
                             rs = ResultScore.objects.get(result=result)
-                            rs.rank = ranked_gene.get('rank', None)
-                            rs.score = ranked_gene.get('score', None)
+                            rs.rank = ranked_gene.get('rank')
+                            rs.score = ranked_gene.get('score')
                         except ResultScore.DoesNotExist:
                             rs = ResultScore(
                                 result=result,
-                                rank=ranked_gene.get('rank', None),
-                                score=ranked_gene.get('score', None))
+                                rank=ranked_gene.get('rank'),
+                                score=ranked_gene.get('score'))
                         rs.save()
 
                         updated_results += 1

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -122,7 +122,10 @@ class Command(BaseCommand):
             # enpoint expects them to be of the form 'HP:0011263'.
             hpo_terms = []
             for hpo_annotation in phenotype_data['hpoAnnotations']:
-                hpo_id = str(hpo_annotation.get('hpo_id', ''))
+                try:
+                    hpo_id = str(hpo_annotation.get('hpo_id', ''))
+                except AttributeError:
+                    continue
 
                 if hpo_id:
                     hpo_terms.append(hpo_id.replace('_', ':'))

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -144,12 +144,14 @@ class Command(BaseCommand):
             # Obviously, if there are no genes then the gene ranking endpoint
             # will have nothing to do so we can safely skip this sample.
             if not genes:
+                log.warning('Skipping "{0}" because it has no genes '
+                            'associated with it.'.format(sample.label))
                 continue
 
             # We need to convert the genes to strings because the ranking
             # service is no prepared to handle the unicode format that the
             # gene symbols are in when we retrieve them from the models.
-            gene_rank_url = "http://{0}?hpo={1}&genes={2}".format(
+            gene_rank_url = "{0}?hpo={1}&genes={2}".format(
                 settings.GENE_RANK_BASE_URL, ",".join(hpo_terms),
                 ",".join([str(g) for g in genes]))
 

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -158,7 +158,8 @@ class Command(BaseCommand):
             try:
                 gene_response = requests.get(gene_rank_url)
             except Exception:
-                log.exception('Error retrieving gene rankings')
+                log.exception('Error retrieving gene rankings, skipping '
+                              'sample "{0}".'.format(sample.label))
                 continue
 
             gene_data = json.loads(gene_response.content)

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -24,17 +24,18 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        if not settings.PHENOTYPE_ENDPOINT:
+        if getattr(settings, 'PHENOTYPE_ENDPOINT', None):
             log.error('PHENOTYPE_ENDPOINT must be defined in settings for '
                       'gene rankings to be updated.')
             return
 
-        if not settings.GENE_RANK_BASE_URL:
+        if getattr(settings, 'GENE_RANK_BASE_URL', None):
             log.error('GENE_RANK_BASE_URL must be defined in settings for '
                       'gene rankings to be updated.')
             return
 
-        if not settings.VARIFY_CERT or not settings.VARIFY_KEY:
+        if (getattr(settings, 'VARIFY_CERT', None) or not
+                getattr(settings, 'VARIFY_KEY', None)):
             log.error('VARIFY_CERT and VARIFY_KEY must be defined in settings '
                       'for gene rankings to be updated.')
             return
@@ -57,6 +58,7 @@ class Command(BaseCommand):
 
         updated_samples = 0
         total_samples = 0
+
         for sample in samples:
             total_samples += 1
 

--- a/varify/samples/management/subcommands/gene_ranks.py
+++ b/varify/samples/management/subcommands/gene_ranks.py
@@ -103,6 +103,13 @@ class Command(BaseCommand):
                          "used then all samples will be updated despite this "
                          "parsing failure.")
 
+            # If the parsed response doesn't contain any HPO terms then we can
+            # skip this sample since we cannot rank genes without HPO terms.
+            if not phenotype_data.get('hpoAnnotations', []):
+                log.error("Response from phenotype missing HPO Annotations, "
+                          "skipping '{0}'.".format(sample.label))
+                continue
+
             if (not force and sample.phenotype_modified and
                     sample.phenotype_modified < phenotype_modified):
                 log.debug("Sample '{0}' is already up to date, skipping it."

--- a/varify/samples/migrations/0033_auto__add_field_sample_phenotype_modified.py
+++ b/varify/samples/migrations/0033_auto__add_field_sample_phenotype_modified.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Sample.phenotype_modified'
+        db.add_column('sample', 'phenotype_modified',
+                      self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Sample.phenotype_modified'
+        db.delete_column('sample', 'phenotype_modified')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'genome.chromosome': {
+            'Meta': {'ordering': "['order']", 'object_name': 'Chromosome', 'db_table': "'chromosome'"},
+            'code': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '2', 'db_index': 'True'})
+        },
+        'genome.genome': {
+            'Meta': {'object_name': 'Genome', 'db_table': "'genome'"},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'released': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'genome.genotype': {
+            'Meta': {'object_name': 'Genotype', 'db_table': "'genotype'"},
+            'code': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '3'})
+        },
+        'literature.pubmed': {
+            'Meta': {'object_name': 'PubMed', 'db_table': "'pubmed'"},
+            'pmid': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'})
+        },
+        'phenotypes.phenotype': {
+            'Meta': {'object_name': 'Phenotype', 'db_table': "'phenotype'"},
+            'articles': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['literature.PubMed']", 'symmetrical': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hpo_id': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '1000'})
+        },
+        'samples.batch': {
+            'Meta': {'ordering': "('project', 'label')", 'unique_together': "(('project', 'name'),)", 'object_name': 'Batch', 'db_table': "'batch'"},
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'investigator': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'batches'", 'to': "orm['samples.Project']"}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'samples.cohort': {
+            'Meta': {'ordering': "('-order', 'name')", 'object_name': 'Cohort', 'db_table': "'cohort'"},
+            'allele_freq_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'autocreated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'batch': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Batch']", 'null': 'True', 'blank': 'True'}),
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'order': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Project']", 'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'samples': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['samples.Sample']", 'through': "orm['samples.CohortSample']", 'symmetrical': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'samples.cohortsample': {
+            'Meta': {'object_name': 'CohortSample', 'db_table': "'cohort_sample'"},
+            'added': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_set': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Cohort']", 'db_column': "'cohort_id'"}),
+            'removed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'set_object': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Sample']", 'db_column': "'sample_id'"})
+        },
+        'samples.cohortvariant': {
+            'Meta': {'unique_together': "(('variant', 'cohort'),)", 'object_name': 'CohortVariant', 'db_table': "'cohort_variant'"},
+            'af': ('django.db.models.fields.FloatField', [], {'null': 'True', 'db_index': 'True'}),
+            'cohort': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Cohort']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'variant': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'cohort_details'", 'to': "orm['variants.Variant']"})
+        },
+        'samples.person': {
+            'Meta': {'object_name': 'Person', 'db_table': "'person'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'mrn': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'proband': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'relations': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['samples.Person']", 'through': "orm['samples.Relation']", 'symmetrical': 'False'}),
+            'sex': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        'samples.project': {
+            'Meta': {'unique_together': "(('name',),)", 'object_name': 'Project', 'db_table': "'project'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'samples.relation': {
+            'Meta': {'ordering': "('person', '-generation')", 'object_name': 'Relation', 'db_table': "'relation'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'generation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'family'", 'to': "orm['samples.Person']"}),
+            'relative': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'relative_of'", 'to': "orm['samples.Person']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'samples.result': {
+            'Meta': {'unique_together': "(('sample', 'variant'),)", 'object_name': 'Result', 'db_table': "'sample_result'"},
+            'base_counts': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'baseq_rank_sum': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'coverage_alt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'coverage_ref': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'downsampling': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'fisher_strand': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'genotype': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['genome.Genotype']", 'null': 'True', 'blank': 'True'}),
+            'genotype_quality': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'haplotype_score': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'homopolymer_run': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_dbsnp': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'mq': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'mq0': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'mq_rank_sum': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'phred_scaled_likelihood': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'quality': ('django.db.models.fields.FloatField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'quality_by_depth': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'raw_read_depth': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'read_depth': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'read_pos_rank_sum': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'sample': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'results'", 'to': "orm['samples.Sample']"}),
+            'spanning_deletions': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'strand_bias': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'variant': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['variants.Variant']"})
+        },
+        'samples.resultscore': {
+            'Meta': {'object_name': 'ResultScore', 'db_table': "'result_score'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'rank': ('django.db.models.fields.IntegerField', [], {}),
+            'result': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'score'", 'unique': 'True', 'to': "orm['samples.Result']"}),
+            'score': ('django.db.models.fields.FloatField', [], {})
+        },
+        'samples.sample': {
+            'Meta': {'ordering': "('project', 'batch', 'label')", 'unique_together': "(('batch', 'name', 'version'),)", 'object_name': 'Sample', 'db_table': "'sample'"},
+            'batch': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'samples'", 'to': "orm['samples.Batch']"}),
+            'bio_sample': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'md5': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'samples'", 'null': 'True', 'to': "orm['samples.Person']"}),
+            'phenotype_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'samples'", 'to': "orm['samples.Project']"}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'vcf_colname': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'samples.samplemanifest': {
+            'Meta': {'object_name': 'SampleManifest', 'db_table': "'sample_manifest'"},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'sample': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'manifest'", 'unique': 'True', 'to': "orm['samples.Sample']"})
+        },
+        'samples.samplerun': {
+            'Meta': {'object_name': 'SampleRun', 'db_table': "'sample_run'"},
+            'completed': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'genome': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['genome.Genome']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'sample': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Sample']"})
+        },
+        'variants.variant': {
+            'Meta': {'unique_together': "(('chr', 'pos', 'ref', 'alt'),)", 'object_name': 'Variant', 'db_table': "'variant'"},
+            'alt': ('django.db.models.fields.TextField', [], {'db_index': 'True'}),
+            'articles': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['literature.PubMed']", 'db_table': "'variant_pubmed'", 'symmetrical': 'False'}),
+            'chr': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['genome.Chromosome']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'liftover': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'md5': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'phenotypes': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['phenotypes.Phenotype']", 'through': "orm['variants.VariantPhenotype']", 'symmetrical': 'False'}),
+            'pos': ('django.db.models.fields.IntegerField', [], {}),
+            'ref': ('django.db.models.fields.TextField', [], {'db_index': 'True'}),
+            'rsid': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['variants.VariantType']", 'null': 'True'})
+        },
+        'variants.variantphenotype': {
+            'Meta': {'object_name': 'VariantPhenotype', 'db_table': "'variant_phenotype'"},
+            'hgmd_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phenotype': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['phenotypes.Phenotype']"}),
+            'variant': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variant_phenotypes'", 'to': "orm['variants.Variant']"})
+        },
+        'variants.varianttype': {
+            'Meta': {'ordering': "['order']", 'object_name': 'VariantType', 'db_table': "'variant_type'"},
+            'code': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['samples']

--- a/varify/samples/models.py
+++ b/varify/samples/models.py
@@ -140,6 +140,12 @@ class Sample(LabeledModel, TimestampedModel):
     md5 = models.CharField(max_length=32, null=True, blank=True,
                            editable=False)
 
+    # This indicates the last time(if any) that this sample had its gene
+    # rankings updated using its associated phenotype terms. Since there is
+    # no guarantee that this sample has been ranked or that it even has
+    # phenotype data, we allow this field to be null.
+    phenotype_modified = models.DateTimeField(null=True, blank=True)
+
     class Meta(LabeledModel.Meta):
         db_table = 'sample'
         unique_together = ('batch', 'name', 'version')

--- a/varify/samples/receivers.py
+++ b/varify/samples/receivers.py
@@ -28,7 +28,7 @@ def update_sample_for_autocreated_cohorts(instance, created, **kwargs):
             world_cohort.save()
         else:
             log.info("World cohort was not found and was not created because "
-                     "VARIFY_AUTO_CREATE_WORLD_COHORT setting is False.")
+                     "VARIFY_AUTO_CREATE_COHORT setting is False.")
             return
 
     project = instance.project

--- a/varify/samples/receivers.py
+++ b/varify/samples/receivers.py
@@ -16,14 +16,20 @@ log = logging.getLogger(__name__)
 @transaction.commit_on_success
 def update_sample_for_autocreated_cohorts(instance, created, **kwargs):
     "Manages adding/removing samples from autocreated cohorts."
+
     # World
     lookup = {'batch': None, 'project': None, 'autocreated': True,
               'name': 'World'}
     try:
         world_cohort = Cohort.objects.get(**lookup)
     except Cohort.DoesNotExist:
-        world_cohort = Cohort(**lookup)
-        world_cohort.save()
+        if getattr(settings, 'VARIFY_AUTO_CREATE_COHORT', True):
+            world_cohort = Cohort(**lookup)
+            world_cohort.save()
+        else:
+            log.info("World cohort was not found and was not created because "
+                     "VARIFY_AUTO_CREATE_WORLD_COHORT setting is False.")
+            return
 
     project = instance.project
 


### PR DESCRIPTION
Fix #41.

This does not directly hook in to the loader. Instead, this can be run as a cron job like `recalculate_frequencies.py` is run now. There is no guarantee that anyone has setup phenotype and gene ranking endpoints so we do not automatically run this during the pipeline loading process.
