### PR TITLE
Add avocado dependency to metatdata migrations

### DIFF
--- a/varify/migrations/0004_avocado_metadata_migration.py
+++ b/varify/migrations/0004_avocado_metadata_migration.py
@@ -2,6 +2,10 @@
 from south.v2 import DataMigration
 
 class Migration(DataMigration):
+    # Force Avocado migrations to run before this migration
+    depends_on = (
+        ('avocado', '0034_auto__add_field_datafield_type'),
+    )
 
     def forwards(self, orm):
         "Perform a 'safe' load using Avocado's backup utilities."

--- a/varify/migrations/0005_avocado_metadata_migration.py
+++ b/varify/migrations/0005_avocado_metadata_migration.py
@@ -2,6 +2,10 @@
 from south.v2 import DataMigration
 
 class Migration(DataMigration):
+    # Force Avocado migrations to run before this migration
+    depends_on = (
+        ('avocado', '0034_auto__add_field_datafield_type'),
+    )
 
     def forwards(self, orm):
         "Perform a 'safe' load using Avocado's backup utilities."

--- a/varify/migrations/0006_avocado_metadata_migration.py
+++ b/varify/migrations/0006_avocado_metadata_migration.py
@@ -2,6 +2,10 @@
 from south.v2 import DataMigration
 
 class Migration(DataMigration):
+    # Force Avocado migrations to run before this migration
+    depends_on = (
+        ('avocado', '0034_auto__add_field_datafield_type'),
+    )
 
     def forwards(self, orm):
         "Perform a 'safe' load using Avocado's backup utilities."

--- a/varify/migrations/0007_avocado_metadata_migration.py
+++ b/varify/migrations/0007_avocado_metadata_migration.py
@@ -2,6 +2,10 @@
 from south.v2 import DataMigration
 
 class Migration(DataMigration):
+    # Force Avocado migrations to run before this migration
+    depends_on = (
+        ('avocado', '0034_auto__add_field_datafield_type'),
+    )
 
     def forwards(self, orm):
         "Perform a 'safe' load using Avocado's backup utilities."

--- a/varify/migrations/0008_avocado_metadata_migration.py
+++ b/varify/migrations/0008_avocado_metadata_migration.py
@@ -2,6 +2,10 @@
 from south.v2 import DataMigration
 
 class Migration(DataMigration):
+    # Force Avocado migrations to run before this migration
+    depends_on = (
+        ('avocado', '0034_auto__add_field_datafield_type'),
+    )
 
     def forwards(self, orm):
         "Perform a 'safe' load using Avocado's backup utilities."

--- a/varify/migrations/0009_avocado_metadata_migration.py
+++ b/varify/migrations/0009_avocado_metadata_migration.py
@@ -2,6 +2,10 @@
 from south.v2 import DataMigration
 
 class Migration(DataMigration):
+    # Force Avocado migrations to run before this migration
+    depends_on = (
+        ('avocado', '0034_auto__add_field_datafield_type'),
+    )
 
     def forwards(self, orm):
         "Perform a 'safe' load using Avocado's backup utilities."


### PR DESCRIPTION
Fix #184.

This dependency is now automatically added to migrations generated with
the avocado 'migration' command but these migrations were created before
that code was added so the dependencies are being retroactively added to
the migrations here.

Signed-off-by: Don Naegely naegelyd@gmail.com
