### PR TITLE
Reset cohort_variant when updating allele frequencies

### DIFF
--- a/varify/samples/models.py
+++ b/varify/samples/models.py
@@ -240,12 +240,6 @@ class Cohort(ObjectSet):
             with transaction.commit_manually(using):
                 # TODO update to use model._meta.db_table..
                 try:
-                    # Raw query to prevent all the overhead of using the
-                    # `delete()` method.
-                    cursor.execute(
-                        'DELETE FROM cohort_variant WHERE cohort_id = %s',
-                        [self.id])
-
                     # Update count on cohort instance
                     cursor.execute('''
                         UPDATE "cohort" SET "count" = (


### PR DESCRIPTION
Clear cohort_variant table and restart cohort_variant_id_seq sequence
when updating allele frequencies to prevent the 'integer out of range'
exception from happening during nightly recalculations.  Fixes #187.

Signed-off-by: Ryan O'Hara oharar@email.chop.edu
