### PR TITLE
Add iptables rule to puppet script to allow 0.0.0.0:8000

### DIFF
--- a/puppet_manifests/base.pp
+++ b/puppet_manifests/base.pp
@@ -40,3 +40,9 @@ service { "memcached":
   enable => true,
   require => Package['memcached']
 }
+
+# Remove bad iptable rule
+exec{ "iptables":
+    path=>$path,
+    command=>"sudo iptables -D INPUT 5;sudo iptables -D FORWARD 1;sudo service iptables save"
+}


### PR DESCRIPTION
Testing GET and query functions for Variants and Phenotype resources

Signed-off-by: Sheik Hassan solergiga@yahoo.com
