### PR TITLE
Update delete-samples command to take multiple ids

### DIFF
--- a/varify/samples/management/subcommands/delete_sample.py
+++ b/varify/samples/management/subcommands/delete_sample.py
@@ -22,12 +22,11 @@ class Command(BaseCommand):
         database = options.get('database')
         cursor = connections[database].cursor()
 
-        assessments = Assessment.objects.filter(
-            sample_result__sample_id__in=args)
+        invalid_ids = set(Assessment.objects.filter(
+            sample_result__sample_id__in=args).values_list(
+            'sample_result__sample_id', flat=True))
 
-        invalid_ids = []
-        if assessments.exists():
-            invalid_ids = assessments.values_list('id', flat=True)
+        if invalid_ids:
             log.warning("Sample(s) with id '{0}' cannot be deleted "
                         "because they have knowledge capture data "
                         "associated with them. If you are absolutely "

--- a/varify/samples/management/subcommands/delete_sample.py
+++ b/varify/samples/management/subcommands/delete_sample.py
@@ -19,55 +19,65 @@ class Command(BaseCommand):
         if not args:
             raise CommandError('A sample ID must be specified')
 
-        sample_id = args[0]
-
-        if Assessment.objects.filter(
-                sample_result__sample_id=sample_id).exists():
-            print("This sample cannot be deleted because it has knowledge "
-                  "capture data associated with it. If you are absolutely "
-                  "sure you want to delete this sample, manually delete the "
-                  "knowledge capture data for this sample and then rerun this "
-                  "command.")
-            return
-
         database = options.get('database')
         cursor = connections[database].cursor()
+
+        assessments = Assessment.objects.filter(
+            sample_result__sample_id__in=args)
+
+        invalid_ids = []
+        if assessments.exists():
+            invalid_ids = assessments.values_list('id', flat=True)
+            log.warning("Sample(s) with id '{0}' cannot be deleted "
+                        "because they have knowledge capture data "
+                        "associated with them. If you are absolutely "
+                        "sure you want to delete these samples, "
+                        "manually delete the knowledge capture data "
+                        "for them and then rerun this command."
+                        .format(", ".join([str(id) for id in invalid_ids])))
+
+        valid_ids = [id for id in args if id not in invalid_ids]
+        columns = ", ".join(['%s' for id in valid_ids])
+
+        if not valid_ids:
+            return
 
         with transaction.commit_manually(database):
             try:
                 # Remove sample from cohorts
                 cursor.execute('''
-                    DELETE FROM cohort_sample WHERE sample_id = %s
-                ''', [sample_id])
+                    DELETE FROM cohort_sample WHERE sample_id IN ({0})
+                '''.format(columns), valid_ids)
 
                 # Remove result scores
                 cursor.execute('''
                     DELETE FROM result_score WHERE result_id IN
-                        (SELECT id from sample_result WHERE sample_id = %s)
-                ''', [sample_id])
+                        (SELECT id from sample_result WHERE sample_id IN ({0}))
+                '''.format(columns), valid_ids)
 
                 # Remove results of sample
                 cursor.execute('''
-                    DELETE FROM sample_result WHERE sample_id = %s
-                ''', [sample_id])
+                    DELETE FROM sample_result WHERE sample_id IN ({0})
+                '''.format(columns), valid_ids)
 
                 # Remove runs from sample
                 cursor.execute('''
-                    DELETE FROM sample_run WHERE sample_id = %s
-                ''', [sample_id])
+                    DELETE FROM sample_run WHERE sample_id IN ({0})
+                '''.format(columns), valid_ids)
 
                 # Remove sample manifest
                 cursor.execute('''
-                    DELETE FROM sample_manifest WHERE sample_id = %s
-                ''', [sample_id])
+                    DELETE FROM sample_manifest WHERE sample_id IN ({0})
+                '''.format(columns), valid_ids)
 
                 # Remove sample
                 cursor.execute('''
-                    DELETE FROM sample WHERE sample.id = %s
-                ''', [sample_id])
+                    DELETE FROM sample WHERE sample.id IN ({0})
+                '''.format(columns), valid_ids)
 
                 transaction.commit()
             except DatabaseError:
                 transaction.rollback()
-                log.exception("Error occurred while deleting sample")
+                log.exception("Error occurred while deleting sample(s) with "
+                              "id '{0}'".format(valid_ids))
                 raise


### PR DESCRIPTION
Fix #261.

The ids are simply arguments after the command, each separated by a space. For example, if we wanted to delete samples with IDs 4 though 8 we could do:

`./bin/manage.py samples delete-sample 4 5 6 7 8`

Signed-off-by: Don Naegely naegelyd@gmail.com
