### PR TITLE
Update postgres versions in puppet_modules

### DIFF
--- a/puppet_modules/postgresql/manifests/devel.pp
+++ b/puppet_modules/postgresql/manifests/devel.pp
@@ -14,21 +14,21 @@ class postgresql::devel {
 
     package {'postgresql92-libs':
               ensure => 'installed',
-              source => 'http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/postgresql92-libs-9.2.6-1PGDG.rhel6.x86_64.rpm',
+              source => 'http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/postgresql92-libs-9.2.8-1PGDG.rhel6.x86_64.rpm',
               provider => 'rpm'
 
     }
             
     package {'postgresql92':
               ensure => 'installed',
-              source => 'http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/postgresql92-9.2.6-1PGDG.rhel6.x86_64.rpm',
+              source => 'http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/postgresql92-9.2.8-1PGDG.rhel6.x86_64.rpm',
               provider => 'rpm',
               require => Package['postgresql92-libs']
     }
 
     package {'postgresql92-devel':
               ensure => 'installed',
-              source => 'http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/postgresql92-devel-9.2.6-1PGDG.rhel6.x86_64.rpm',
+              source => 'http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/postgresql92-devel-9.2.8-1PGDG.rhel6.x86_64.rpm',
               provider => 'rpm',
               require => Package['postgresql92']
               }


### PR DESCRIPTION
Fixes #245. The yum repo for postgres no longer contains the original
packages that the Vagrant VM referenced (via dependencies defined by
puppet). This updates them to use the 9.2.8 versions of lib, devel, and
server.

Signed-off-by: Michael Italia ITALIAM@email.chop.edu
