### PR TITLE
Migration bug fix

### DIFF
--- a/varify/conf/global_settings.py
+++ b/varify/conf/global_settings.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.staticfiles',
 
+    'varify.samples',
     'varify',
 
     'varify.raw',
@@ -34,7 +35,6 @@ INSTALLED_APPS = (
     'varify.genes',
     'varify.variants',
     'varify.phenotypes',
-    'varify.samples',
     'varify.literature',
 
     'varify.support',
@@ -58,6 +58,7 @@ INSTALLED_APPS = (
     'modeltree',
     'guardian',
     'reversion',
+
 )
 
 


### PR DESCRIPTION
Fix #268
Problem as described by @naegelyd 
`The issue was that permissions and content types for models in an app are automatically created int he DB when the app is created. The initial_data has natural keys for content types in the permissions list referring to the samples app so that is why it needs to be first`
Signed-off-by: Sheik Hassan solergiga@yahoo.com
