### PR TITLE
Add migration dependencies to resolve DeserializationError

### DIFF
--- a/varify/migrations/0001_initial.py
+++ b/varify/migrations/0001_initial.py
@@ -7,6 +7,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('samples', '0001_initial'),
+    )
+
     def forwards(self, orm):
         pass
 
@@ -14,7 +18,7 @@ class Migration(SchemaMigration):
         pass
 
     models = {
-        
+
     }
 
     complete_apps = ['varify']

--- a/varify/samples/migrations/0001_initial.py
+++ b/varify/samples/migrations/0001_initial.py
@@ -7,6 +7,7 @@ from django.db import models
 class Migration(SchemaMigration):
 
     depends_on = (
+        ('avocado', '0034_auto__add_field_datafield_type'),
         ('variants', '0001_initial'),
     )
 


### PR DESCRIPTION
Fix: #268.

The initial_data.json fixture for the varify app depends on the Permission and ContentType records for the samples app to be in the DB. To accomplish this, varify's initial migration now depends on samples's initial migration to force the permissions and types to be created.

Signed-off-by: Don Naegely naegelyd@gmail.com
