### PR TITLE
Convert cohort_variant and result primary key types to bigint

### DIFF
--- a/tests/cases/commands/tests.py
+++ b/tests/cases/commands/tests.py
@@ -11,6 +11,7 @@ from varify.assessments.models import Assessment, Pathogenicity, \
     ParentalResult, AssessmentCategory
 from varify.samples.models import Sample, CohortSample, Result, SampleRun, \
     SampleManifest, Project, Cohort, Batch, CohortVariant, ResultScore
+from varify.variants.models import Variant
 from varify.samples.management.subcommands import gene_ranks
 from ..sample_load_process.tests import QueueTestCase
 from ...models import MockHandler
@@ -666,3 +667,41 @@ class AlleleTestCase(QueueTestCase):
         self.assertNotEqual(firstCount, 0)
         management.call_command('samples', 'allele-freqs')
         self.assertEqual(firstCount, CohortVariant.objects.count())
+
+
+@override_settings(VARIFY_SAMPLE_DIRS=SAMPLE_DIRS)
+class BigAutoFieldsTestCase(TestCase):
+    def setUp(self):
+        self.project = Project(id=1, name='', label='')
+        self.project.save()
+        self.batch = Batch(id=1, name='', project_id=self.project.id, label='')
+        self.batch.save()
+
+    def test_big_auto_fields(self):
+        # Test that BigAutoFields can exceed Django's default integer limit
+        result_count_before = Result.objects.count()
+        cohort_variant_count_before = CohortVariant.objects.count()
+        two_hundred_billion = int(200e9)
+
+        new_sample = Sample.objects.create(
+            id=1, label='',batch_id=self.batch.id, version=1,
+            count=1, published=True, name='', project_id=self.project.id)
+        
+        new_variant = Variant.objects.create(
+            id=1, chr_id=1, pos=1, ref='', alt='', md5='')
+
+        new_result = Result.objects.create(
+            id=two_hundred_billion, sample_id=new_sample.id,
+            variant_id=new_variant.id)
+
+        new_score = ResultScore.objects.create(
+            id=1, result_id=new_result.id, rank=0, score=0)
+        
+        new_cohort_variant = CohortVariant.objects.create(
+            id=two_hundred_billion, variant_id=new_variant.id, cohort_id=1)
+        
+        result_count_after = Result.objects.count()        
+        cohort_variant_count_after = CohortVariant.objects.count()
+    
+        self.assertEqual(result_count_before+1, result_count_after)
+        self.assertEqual(cohort_variant_count_before+1, cohort_variant_count_after)

--- a/varify/assessments/models.py
+++ b/varify/assessments/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
+from varify.core.models import BigForeignKey
 from varify.samples.models import Result
 from varify.core.models import TimestampedModel
 import reversion
@@ -52,7 +53,8 @@ class Assessment(TimestampedModel):
     father_result = models.ForeignKey(ParentalResult, related_name='father')
     mother_result = models.ForeignKey(ParentalResult, related_name='mother')
     pathogenicity = models.ForeignKey(Pathogenicity)
-    sample_result = models.ForeignKey(Result)
+    sample_result = BigForeignKey(Result)
+
     sanger_result = models.ForeignKey(SangerResult, null=True, blank=True)
     user = models.ForeignKey(User)
 

--- a/varify/core/models.py
+++ b/varify/core/models.py
@@ -1,4 +1,7 @@
+from django.core import exceptions
 from django.db import models
+from django.db.models import fields
+from south.modelsinspector import add_introspection_rules
 
 
 class TimestampedModel(models.Model):
@@ -28,3 +31,61 @@ class LabeledModel(models.Model):
 
     def __unicode__(self):
         return self.label
+
+
+class BigIntegerField(fields.IntegerField):
+    def db_type(self, connection):
+        if 'postgres' in connection.__class__.__module__:
+            return 'bigint'
+        else:
+            raise NotImplemented
+
+    def get_internal_type(self):
+        return 'BigIntegerField'
+
+    def to_python(self, value):
+        if value is None:
+            return value
+        try:
+            return long(value)
+        except (TypeError, ValueError):
+            raise exceptions.ValidationError(
+                'This value must be a long integer.')
+
+
+class BigAutoField(fields.AutoField):
+    # ONLY PostgreSQL is supported (MySQL, Oracle & SQLite are NOT supported)
+    def db_type(self, connection):
+        if 'postgres' in connection.__class__.__module__:
+            return 'bigserial'
+        else:
+            raise NotImplemented
+
+    def get_internal_type(self):
+        return 'BigAutoField'
+
+    def to_python(self, value):
+        if value is None:
+            return value
+        try:
+            return long(value)
+        except (TypeError, ValueError):
+            raise exceptions.ValidationError(
+                'This value must be a long integer.')
+
+
+class BigForeignKey(fields.related.ForeignKey):
+    def db_type(self, connection):
+        rel_field = self.rel.get_related_field()
+        is_bigauto = isinstance(rel_field, BigAutoField)
+        is_bigint = isinstance(rel_field, BigIntegerField)
+        matches_type = connection.features.related_fields_match_type
+        if (is_bigauto or (not matches_type and is_bigint)):
+
+            return BigIntegerField().db_type(connection)
+        return rel_field.db_type(connection)
+
+
+add_introspection_rules([], ["^varify\.core\.models\.BigIntegerField"])
+add_introspection_rules([], ["^varify\.core\.models\.BigAutoField"])
+add_introspection_rules([], ["^varify\.core\.models\.BigForeignKey"])

--- a/varify/samples/migrations/0034_auto__chg_field_cohortvariant_id__chg_field_result_id.py
+++ b/varify/samples/migrations/0034_auto__chg_field_cohortvariant_id__chg_field_result_id.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+    # Backwards migration is NOT supported.
+    # MySQL, Oracle, and SQLite are NOT supported.
+    # ONLY forward migration in PostgreSQL is supported.
+    def forwards(self, orm):
+        # Changing field 'CohortVariant.id'
+        # Override auto generated migration code
+        db.execute('ALTER TABLE "cohort_variant" ALTER COLUMN "id" TYPE bigint')
+
+        # Changing field 'Result.id'
+        # Override auto generated migration code
+        db.execute('ALTER TABLE "sample_result" ALTER COLUMN "id" TYPE bigint')
+        # Change FK fields 'result_score.result_id' and 'assessment.sample_result_id'
+        db.execute('ALTER TABLE "result_score" ALTER COLUMN "result_id" TYPE bigint')
+        db.execute('ALTER TABLE "assessment" ALTER COLUMN "sample_result_id" TYPE bigint')
+
+    def backwards(self, orm):
+        raise RuntimeError("Cannot convert bigint to integer")
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'genome.chromosome': {
+            'Meta': {'ordering': "['order']", 'object_name': 'Chromosome', 'db_table': "'chromosome'"},
+            'code': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '2', 'db_index': 'True'})
+        },
+        'genome.genome': {
+            'Meta': {'object_name': 'Genome', 'db_table': "'genome'"},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'released': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'genome.genotype': {
+            'Meta': {'object_name': 'Genotype', 'db_table': "'genotype'"},
+            'code': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '3'})
+        },
+        'literature.pubmed': {
+            'Meta': {'object_name': 'PubMed', 'db_table': "'pubmed'"},
+            'pmid': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'})
+        },
+        'phenotypes.phenotype': {
+            'Meta': {'object_name': 'Phenotype', 'db_table': "'phenotype'"},
+            'articles': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['literature.PubMed']", 'symmetrical': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hpo_id': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '1000'})
+        },
+        'samples.batch': {
+            'Meta': {'ordering': "('project', 'label')", 'unique_together': "(('project', 'name'),)", 'object_name': 'Batch', 'db_table': "'batch'"},
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'investigator': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'batches'", 'to': "orm['samples.Project']"}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'samples.cohort': {
+            'Meta': {'ordering': "('-order', 'name')", 'object_name': 'Cohort', 'db_table': "'cohort'"},
+            'allele_freq_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'autocreated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'batch': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Batch']", 'null': 'True', 'blank': 'True'}),
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'order': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Project']", 'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'samples': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['samples.Sample']", 'through': "orm['samples.CohortSample']", 'symmetrical': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'samples.cohortsample': {
+            'Meta': {'object_name': 'CohortSample', 'db_table': "'cohort_sample'"},
+            'added': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_set': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Cohort']", 'db_column': "'cohort_id'"}),
+            'removed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'set_object': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Sample']", 'db_column': "'sample_id'"})
+        },
+        'samples.cohortvariant': {
+            'Meta': {'unique_together': "(('variant', 'cohort'),)", 'object_name': 'CohortVariant', 'db_table': "'cohort_variant'"},
+            'af': ('django.db.models.fields.FloatField', [], {'null': 'True', 'db_index': 'True'}),
+            'cohort': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Cohort']"}),
+            'id': ('varify.core.models.BigAutoField', [], {'primary_key': 'True'}),
+            'variant': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'cohort_details'", 'to': "orm['variants.Variant']"})
+        },
+        'samples.person': {
+            'Meta': {'object_name': 'Person', 'db_table': "'person'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'mrn': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'proband': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'relations': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['samples.Person']", 'through': "orm['samples.Relation']", 'symmetrical': 'False'}),
+            'sex': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        'samples.project': {
+            'Meta': {'unique_together': "(('name',),)", 'object_name': 'Project', 'db_table': "'project'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'samples.relation': {
+            'Meta': {'ordering': "('person', '-generation')", 'object_name': 'Relation', 'db_table': "'relation'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'generation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'family'", 'to': "orm['samples.Person']"}),
+            'relative': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'relative_of'", 'to': "orm['samples.Person']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'samples.result': {
+            'Meta': {'unique_together': "(('sample', 'variant'),)", 'object_name': 'Result', 'db_table': "'sample_result'"},
+            'base_counts': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'baseq_rank_sum': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'coverage_alt': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'coverage_ref': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'downsampling': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'fisher_strand': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'genotype': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['genome.Genotype']", 'null': 'True', 'blank': 'True'}),
+            'genotype_quality': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'haplotype_score': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'homopolymer_run': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('varify.core.models.BigAutoField', [], {'primary_key': 'True'}),
+            'in_dbsnp': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'mq': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'mq0': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'mq_rank_sum': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'phred_scaled_likelihood': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'quality': ('django.db.models.fields.FloatField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'quality_by_depth': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'raw_read_depth': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'read_depth': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'read_pos_rank_sum': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'sample': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'results'", 'to': "orm['samples.Sample']"}),
+            'spanning_deletions': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'strand_bias': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'variant': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['variants.Variant']"})
+        },
+        'samples.resultscore': {
+            'Meta': {'object_name': 'ResultScore', 'db_table': "'result_score'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'rank': ('django.db.models.fields.IntegerField', [], {}),
+            'result': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'score'", 'unique': 'True', 'to': "orm['samples.Result']"}),
+            'score': ('django.db.models.fields.FloatField', [], {})
+        },
+        'samples.sample': {
+            'Meta': {'ordering': "('project', 'batch', 'label')", 'unique_together': "(('batch', 'name', 'version'),)", 'object_name': 'Sample', 'db_table': "'sample'"},
+            'batch': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'samples'", 'to': "orm['samples.Batch']"}),
+            'bio_sample': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'md5': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'samples'", 'null': 'True', 'to': "orm['samples.Person']"}),
+            'phenotype_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'samples'", 'to': "orm['samples.Project']"}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'vcf_colname': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'samples.samplemanifest': {
+            'Meta': {'object_name': 'SampleManifest', 'db_table': "'sample_manifest'"},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'sample': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'manifest'", 'unique': 'True', 'to': "orm['samples.Sample']"})
+        },
+        'samples.samplerun': {
+            'Meta': {'object_name': 'SampleRun', 'db_table': "'sample_run'"},
+            'completed': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'genome': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['genome.Genome']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'sample': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Sample']"})
+        },
+        'variants.variant': {
+            'Meta': {'unique_together': "(('chr', 'pos', 'ref', 'alt'),)", 'object_name': 'Variant', 'db_table': "'variant'"},
+            'alt': ('django.db.models.fields.TextField', [], {'db_index': 'True'}),
+            'articles': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['literature.PubMed']", 'db_table': "'variant_pubmed'", 'symmetrical': 'False'}),
+            'chr': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['genome.Chromosome']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'liftover': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'md5': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'phenotypes': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['phenotypes.Phenotype']", 'through': "orm['variants.VariantPhenotype']", 'symmetrical': 'False'}),
+            'pos': ('django.db.models.fields.IntegerField', [], {}),
+            'ref': ('django.db.models.fields.TextField', [], {'db_index': 'True'}),
+            'rsid': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['variants.VariantType']", 'null': 'True'})
+        },
+        'variants.variantphenotype': {
+            'Meta': {'object_name': 'VariantPhenotype', 'db_table': "'variant_phenotype'"},
+            'hgmd_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phenotype': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['phenotypes.Phenotype']"}),
+            'variant': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variant_phenotypes'", 'to': "orm['variants.Variant']"})
+        },
+        'variants.varianttype': {
+            'Meta': {'ordering': "['order']", 'object_name': 'VariantType', 'db_table': "'variant_type'"},
+            'code': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['samples']
+    

--- a/varify/samples/models.py
+++ b/varify/samples/models.py
@@ -5,6 +5,7 @@ from django.db import router, models, transaction, connections, DatabaseError
 from sts.contextmanagers import transition
 from objectset.models import ObjectSet, SetObject
 from varify.core.models import TimestampedModel, LabeledModel
+from varify.core.models import BigAutoField, BigForeignKey
 from varify.genome.models import Genome, Genotype
 from varify.variants.models import Variant
 
@@ -284,6 +285,10 @@ class CohortVariant(models.Model):
     """Cohort-level aggregated data relative to specific variants. This
     currently only includes 'allele frequency' for the given cohort.
     """
+
+    # Explictly declare BigAutoField primary key to avoid reaching max int
+    id = BigAutoField(primary_key=True)
+
     variant = models.ForeignKey(Variant, related_name='cohort_details')
     cohort = models.ForeignKey(Cohort)
     af = models.FloatField(null=True, db_index=True)
@@ -307,6 +312,9 @@ class SampleRun(TimestampedModel):
 
 
 class Result(TimestampedModel):
+    # Explictly declare BigAutoField primary key to avoid reaching max int
+    id = BigAutoField(primary_key=True)
+
     # Reference to the sample
     sample = models.ForeignKey(Sample, related_name='results')
 
@@ -376,7 +384,7 @@ class Result(TimestampedModel):
 
 
 class ResultScore(TimestampedModel):
-    result = models.ForeignKey(Result, related_name='score', unique=True)
+    result = BigForeignKey(Result, related_name='score', unique=True)
     rank = models.IntegerField()
     score = models.FloatField()
 


### PR DESCRIPTION
Backwards migration is NOT supported.
MySQL, Oracle, and SQLite are NOT supported.
ONLY forward migration in PostgreSQL is supported.
Resolves #222

Signed-off-by: Ryan O'Hara oharar@email.chop.edu
