### PR TITLE
Remove system_site_packages flag in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ python:
 env:
     - DJANGO=1.4.11
 
-virtualenv:
-    system_site_packages: true
-
 before_install:
     - env | sort
     - sudo apt-get update -qq


### PR DESCRIPTION
Fixes issue where all builds for python 2.6 were failing. More details can be found [here](https://github.com/travis-ci/travis-ci/issues/2219).

Signed-off-by: Don Naegely naegelyd@gmail.com
