### PR TITLE
Fallback to default cache when loading samples

### DIFF
--- a/varify/pipeline/__init__.py
+++ b/varify/pipeline/__init__.py
@@ -3,7 +3,7 @@ from avocado.core.loader import autodiscover
 from .utils import Channel, job, ManifestReader     # noqa
 
 PIPELINE_CACHE_ALIAS = \
-    getattr(settings, 'VARIFY_PIPELINE_CACHE_ALIAS', 'varify.pipeline')
+    getattr(settings, 'VARIFY_PIPELINE_CACHE_ALIAS', 'default')
 
 # Creates a pipeline component registry. `pipeline` modules or packages in
 # apps that are _installed_ will be autoloaded which enables auto-registering


### PR DESCRIPTION
Both varify.pipline and default seem to be the exact same caches. The former however, is confused for a module of the same name, causing nasty errors when loading samples.

Signed-off-by: Sheik Hassan solergiga@yahoo.com
