### PR TITLE
Don't hide loading overlay until variant data is returned

### DIFF
--- a/varify/static/js/src/ui/tables/body.js
+++ b/varify/static/js/src/ui/tables/body.js
@@ -24,11 +24,16 @@ define([
         },
 
         _fetch: function() {
+            var _this = this;
+
             this.collection.fetch({
                 data: JSON.stringify({ids: this._collection.pluck('pk')}),
                 type: 'POST',
                 contentType: 'application/json',
-                parse: true
+                parse: true,
+                success: function() {
+                    _this.trigger('synced');
+                }
             });
         },
 

--- a/varify/static/js/src/ui/workflows/results.js
+++ b/varify/static/js/src/ui/workflows/results.js
@@ -53,7 +53,18 @@ define([
         },
 
         initialize: function() {
+            _.bindAll(this, 'hideLoadingOverlay');
+
             c.ui.ResultsWorkflow.prototype.initialize.call(this);
+
+            // We will manage the hiding of the loading overlay ourselves. The
+            // call to the preview endpoint returns the variant IDs. The actual
+            // variant data is retrieved by another call after the call to the
+            // preview endpoint comes back so we cannot let Cilantro hide the
+            // overlay after the preview endpoint syncs like it normally does.
+            // Insted, we need to hide it after the variant collection becomes
+            // synced.
+            this.stopListening(this.data.results, 'sync');
 
             // The Cilantro workflow no longer requires the context but we
             // need it to have any hope of referencing the sample name in the
@@ -85,7 +96,10 @@ define([
                 view: this.data.view,
                 collection: this.data.results
             }));
-
+            // When the body of the table reports that it is synced, then the
+            // variant data has arrived and we can now hide the loading
+            // overlay.
+            this.table.currentView.on('itemview:synced', this.hideLoadingOverlay);
 
             this.ui.navbarButtons.tooltip({
                 animation: false,


### PR DESCRIPTION
Fix #358.

This fixes a bug where the loading overlay was being hidden by Cilantro
as soon as the call to /api/data/preview/ returned which was problematic
in Varify because the variant data is not retrieved by that call but
instead comes back in a successive call to /api/samples/variants/. The
loading overlay is now hidden after that second call.

Signed-off-by: Don Naegely naegelyd@gmail.com
